### PR TITLE
1)加入unionid 机制.

### DIFF
--- a/mp/user/oauth2/oauth2.go
+++ b/mp/user/oauth2/oauth2.go
@@ -46,6 +46,8 @@ type OAuth2Token struct {
 
 	OpenId string
 	Scopes []string // 用户授权的作用域
+
+	UnionId string // UnionID机制
 }
 
 // 判断授权的 OAuth2Token.AccessToken 是否过期, 过期返回 true, 否则返回 false
@@ -196,6 +198,7 @@ func (clt *Client) updateToken(tk *OAuth2Token, url string) (err error) {
 		ExpiresIn    int64  `json:"expires_in"`    // access_token接口调用凭证超时时间，单位（秒）
 		OpenId       string `json:"openid"`        // 用户唯一标识，请注意，在未关注公众号时，用户访问公众号的网页，也会产生一个用户和公众号唯一的OpenID
 		Scope        string `json:"scope"`         // 用户授权的作用域，使用逗号（,）分隔
+		UnionId      string `json:"unionid"`       // UnionID机制
 	}
 
 	if err = json.NewDecoder(httpResp.Body).Decode(&result); err != nil {
@@ -241,5 +244,8 @@ func (clt *Client) updateToken(tk *OAuth2Token, url string) (err error) {
 		}
 		tk.Scopes = append(tk.Scopes, str)
 	}
+
+	tk.UnionId = result.UnionId
+
 	return
 }


### PR DESCRIPTION
关于UnionID机制

1、请注意，网页授权获取用户基本信息也遵循UnionID机制。即如果开发者有在多个公众号，或在公众号、移动应用之间统一用户帐号的需求，需要前往微信开放平台（open.weixin.qq.com）绑定公众号后，才可利用UnionID机制来满足上述需求。
2、UnionID机制的作用说明：如果开发者拥有多个移动应用、网站应用和公众帐号，可通过获取用户基本信息中的unionid来区分用户的唯一性，因为同一用户，对同一个微信开放平台下的不同应用（移动应用、网站应用和公众帐号），unionid是相同的。

http://mp.weixin.qq.com/wiki/17/c0f37d5704f0b64713d5d2c37b468d75.html
