### PR TITLE
fix: 当微信的用户中含有非法字符导致json库不能解析时删除非法字符

### DIFF
--- a/mp/client.go
+++ b/mp/client.go
@@ -89,7 +89,7 @@ RETRY:
 
 	if err = json.NewDecoder(httpResp.Body).Decode(response); err != nil {
 		if err = json.NewDecoder(httpResp.Body).Decode(response); err != nil {
-			if !strings.Contains(err.Error(), "invalid character '") {
+			if !strings.Contains(err.Error(), "invalid character '") && !strings.Contains(err.Error(), "json: cannot unmarshal") {
 				LogInfoln("[WeChat JSON Error] ", err.Error())
 				return
 			} else {
@@ -174,7 +174,7 @@ RETRY:
 	}
 	httpResp.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
 	if err = json.NewDecoder(httpResp.Body).Decode(response); err != nil {
-		if !strings.Contains(err.Error(), "invalid character '") {
+		if !strings.Contains(err.Error(), "invalid character '") && !strings.Contains(err.Error(), "json: cannot unmarshal") {
 			LogInfoln("[WeChat JSON Error] ", err.Error())
 			return
 		} else {

--- a/mp/client.go
+++ b/mp/client.go
@@ -158,20 +158,9 @@ RETRY:
 	httpResp.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
 	if err = json.NewDecoder(httpResp.Body).Decode(response); err != nil {
 		if !strings.Contains(err.Error(), "invalid character '\\") {
-			LogInfoln("find error")
 			return
 		} else {
-			var str = string(bodyBytes)
-			b := make([]byte, len(str))
-			var bl int
-			for i := 0; i < len(str); i++ {
-				c := str[i]
-				if c >= 32 && c != 127 {
-					b[bl] = c
-					bl++
-				}
-			}
-			if err = json.Unmarshal(b[:bl], response); err != nil {
+			if err = json.Unmarshal(EscapeCtrl(bodyBytes), response); err != nil {
 				return
 			}
 		}


### PR DESCRIPTION
形如：

``` json
{
  "subscribe": 1,
  "openid": "o3vWouK5hzOik6qig2dCbNHx11V4",
  "nickname": "尐嘴\u0007乿親",
  "sex": 2,
  "language": "zh_CN",
  "city": "南昌",
  "province": "江西",
  "country": "中国",
  "headimgurl": "http://wx.qlogo.cn/mmopen/hzVGicX27IG3O4eszxHM02frvj67MHoolT762CrXwWeByu18kqTeg3JS2dKV2SfhOH4UozfAShV8MtGlttHzgNw/0",
  "subscribe_time": 1386216882,
  "remark": "",
  "groupid": 0
}
```
