### PR TITLE
add link msg type

### DIFF
--- a/corp/message/request/msg.go
+++ b/corp/message/request/msg.go
@@ -16,6 +16,7 @@ const (
 	MsgTypeVoice    = "voice"    // 语音消息
 	MsgTypeVideo    = "video"    // 视频消息
 	MsgTypeLocation = "location" // 地理位置消息
+	MsgTypeLink = "link" // 连接消息
 )
 
 type Text struct {
@@ -31,6 +32,25 @@ func GetText(msg *corp.MixedMessage) *Text {
 		MessageHeader: msg.MessageHeader,
 		MsgId:         msg.MsgId,
 		Content:       msg.Content,
+	}
+}
+type Link struct {
+	XMLName struct{} `xml:"xml" json:"-"`
+	corp.MessageHeader
+	MsgId   int64  `xml:"MsgId"   json:"MsgId"`   // 消息id, 64位整型
+	Title   string `xml:"Title" json:"Title"` // 文本消息内容
+        Description string `xml:"Description" json:"Description"`
+       Url string  `xml:"Url" json:"Url"`
+}
+
+
+func GetLink(msg *corp.MixedMessage) *Link {
+	return &Link{
+		MessageHeader: msg.MessageHeader,
+		MsgId:         msg.MsgId,
+		Title:         msg.Title,
+		Description:  msg.Description,
+		Url:          msg.Url,
 	}
 }
 

--- a/corp/msg_handler.go
+++ b/corp/msg_handler.go
@@ -66,6 +66,10 @@ type MixedMessage struct {
 	LocationY    float64 `xml:"Location_Y"   json:"Location_Y"`
 	Scale        int     `xml:"Scale"        json:"Scale"`
 	Label        string  `xml:"Label"        json:"Label"`
+ 
+        Title   string `xml:"Title" json:"Title"` // 文本消息内容
+        Description string `xml:"Description" json:"Description"`
+       Url string  `xml:"Url" json:"Url"`
 
 	Event    string `xml:"Event"    json:"Event"`
 	EventKey string `xml:"EventKey" json:"EventKey"`


### PR DESCRIPTION
添加企业号  链接消息类型支持， 请采纳。

使用方法：

路由中调用：
 messageServeMux.MessageHandleFunc(request.MsgTypeLink, MsgTypeLinkHandler)

处理逻辑
func MsgTypeLinkHandler(w http.ResponseWriter, r *corp.Request) {
    msgs := request.GetLink(r.MixedMsg)
    log.Println( msgs.ToUserName, msgs.FromUserName, msgs.MsgType )
    log.Println( msgs.Url, msgs.Title, msgs.Description )
}
