### PR TITLE
更新推送小程序卡片需要的参数

### DIFF
--- a/mp/message/custom/msg.go
+++ b/mp/message/custom/msg.go
@@ -14,6 +14,7 @@ const (
 	MsgTypeMPNews     core.MsgType = "mpnews" // 图文消息, 发送已经创建好的图文
 	MsgTypeWxCard     core.MsgType = "wxcard" // 卡卷消息
 	MsgTypeWxMiniLink core.MsgType = "link"   // 小程序客服消息:图文链接
+	MsgTypeWxMiniPage core.MsgType = "miniprogrampage" //小程序卡片
 )
 
 type MsgHeader struct {
@@ -308,20 +309,21 @@ type WxMiniPage struct {
 	MsgHeader
 	MiniProgramPage struct {
 		Title        string `json:"title"`
+		AppId        string `json:"appid"`
 		PagePath     string `json:"pagepath"`
 		ThumbMediaId string `json:"thumb_media_id"`
 	} `json:"miniprogrampage"`
 	CustomService *CustomService `json:"customservice,omitempty"`
 }
 
-func NewMiniPage(toUser, title, pagePath, thumbMediaId, kfAccount string) (page *WxMiniPage) {
+func NewMiniPage(toUser,appId ,title, pagePath, thumbMediaId, kfAccount string) (page *WxMiniPage) {
 	page = &WxMiniPage{
 		MsgHeader: MsgHeader{
 			ToUser:  toUser,
-			MsgType: MsgTypeWxMiniLink,
+			MsgType: MsgTypeWxMiniPage,
 		},
 	}
-
+	page.MiniProgramPage.AppId = appId
 	page.MiniProgramPage.Title = title
 	page.MiniProgramPage.PagePath = pagePath
 	page.MiniProgramPage.ThumbMediaId = thumbMediaId


### PR DESCRIPTION
小程序卡片的推送需要小程序的appId以及MsgType为MsgTypeWxMiniPage,不然无法推送小程序消息。修改了func NewMiniPage的参数。之前的肯定都是发不出去的了。因为发送到微信的参数不全面。