### PR TITLE
fix: 客服消息发送小程序卡片

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/chanxuehong/rand v0.0.0-20180830053958-4b3aff17f488 h1:6d1ijTov542DDRWsFdnPYeGWnlRxlzbpEaJuNJtBQiU=
 github.com/chanxuehong/rand v0.0.0-20180830053958-4b3aff17f488/go.mod h1:h13adSJmQ5tsaV9bR72eTp7ePXJ2WIWyK6heLeietxA=
+github.com/chanxuehong/util v0.0.0-20181116100727-caf892acd09c h1:+bidl2o5S+JFtpiJdUPrgHYE922v3RgHKPqzojUVRyw=
 github.com/chanxuehong/util v0.0.0-20181116100727-caf892acd09c/go.mod h1:oCc2u0egGweOE68RdURGznc2LgbCrdGAAkXOQw2CuNM=

--- a/mp/message/custom/msg.go
+++ b/mp/message/custom/msg.go
@@ -14,7 +14,7 @@ const (
 	MsgTypeMPNews     core.MsgType = "mpnews"          // 图文消息, 发送已经创建好的图文
 	MsgTypeWxCard     core.MsgType = "wxcard"          // 卡卷消息
 	MsgTypeWxMiniLink core.MsgType = "link"            // 小程序客服消息:图文链接
-	MsgTypeWxMiniPage core.MsgType = "miniprogrampage" // 小程序客服消息:图文链接
+	MsgTypeWxMiniPage core.MsgType = "miniprogrampage" // 小程序客服消息:小程序卡片
 )
 
 type MsgHeader struct {
@@ -309,13 +309,14 @@ type WxMiniPage struct {
 	MsgHeader
 	MiniProgramPage struct {
 		Title        string `json:"title"`
+		AppId        string `json:"appid"`
 		PagePath     string `json:"pagepath"`
 		ThumbMediaId string `json:"thumb_media_id"`
 	} `json:"miniprogrampage"`
 	CustomService *CustomService `json:"customservice,omitempty"`
 }
 
-func NewMiniPage(toUser, title, pagePath, thumbMediaId, kfAccount string) (page *WxMiniPage) {
+func NewMiniPage(toUser, title, appId, pagePath, thumbMediaId, kfAccount string) (page *WxMiniPage) {
 	page = &WxMiniPage{
 		MsgHeader: MsgHeader{
 			ToUser:  toUser,
@@ -324,6 +325,7 @@ func NewMiniPage(toUser, title, pagePath, thumbMediaId, kfAccount string) (page 
 	}
 
 	page.MiniProgramPage.Title = title
+	page.MiniProgramPage.AppId = appId
 	page.MiniProgramPage.PagePath = pagePath
 	page.MiniProgramPage.ThumbMediaId = thumbMediaId
 	if kfAccount != "" {

--- a/mp/message/custom/msg.go
+++ b/mp/message/custom/msg.go
@@ -5,15 +5,16 @@ import (
 )
 
 const (
-	MsgTypeText       core.MsgType = "text"   // 文本消息
-	MsgTypeImage      core.MsgType = "image"  // 图片消息
-	MsgTypeVoice      core.MsgType = "voice"  // 语音消息
-	MsgTypeVideo      core.MsgType = "video"  // 视频消息
-	MsgTypeMusic      core.MsgType = "music"  // 音乐消息
-	MsgTypeNews       core.MsgType = "news"   // 图文消息
-	MsgTypeMPNews     core.MsgType = "mpnews" // 图文消息, 发送已经创建好的图文
-	MsgTypeWxCard     core.MsgType = "wxcard" // 卡卷消息
-	MsgTypeWxMiniLink core.MsgType = "link"   // 小程序客服消息:图文链接
+	MsgTypeText       core.MsgType = "text"            // 文本消息
+	MsgTypeImage      core.MsgType = "image"           // 图片消息
+	MsgTypeVoice      core.MsgType = "voice"           // 语音消息
+	MsgTypeVideo      core.MsgType = "video"           // 视频消息
+	MsgTypeMusic      core.MsgType = "music"           // 音乐消息
+	MsgTypeNews       core.MsgType = "news"            // 图文消息
+	MsgTypeMPNews     core.MsgType = "mpnews"          // 图文消息, 发送已经创建好的图文
+	MsgTypeWxCard     core.MsgType = "wxcard"          // 卡卷消息
+	MsgTypeWxMiniLink core.MsgType = "link"            // 小程序客服消息:图文链接
+	MsgTypeWxMiniPage core.MsgType = "miniprogrampage" // 小程序客服消息:图文链接
 )
 
 type MsgHeader struct {
@@ -318,7 +319,7 @@ func NewMiniPage(toUser, title, pagePath, thumbMediaId, kfAccount string) (page 
 	page = &WxMiniPage{
 		MsgHeader: MsgHeader{
 			ToUser:  toUser,
-			MsgType: MsgTypeWxMiniLink,
+			MsgType: MsgTypeWxMiniPage,
 		},
 	}
 


### PR DESCRIPTION
现在的公众号客服消息推送小程序卡片是有问题的
1. MessageType误设置为了link，实际上应该为miniprogrampage
https://github.com/chanxuehong/wechat/blob/fafb751f9916a5e91a45e19f91f1982a82f47b34/mp/message/custom/msg.go#L321

2. message中的miniprogrampage字段缺少appid属性
https://github.com/chanxuehong/wechat/blob/fafb751f9916a5e91a45e19f91f1982a82f47b34/mp/message/custom/msg.go#L311

参考文档：
https://developers.weixin.qq.com/doc/offiaccount/Message_Management/Service_Center_messages.html
<img width="535" alt="image" src="https://user-images.githubusercontent.com/16649269/71774512-51697400-2fab-11ea-9759-19c0139ee072.png">
